### PR TITLE
Fix Turkish language bug.

### DIFF
--- a/src/main/java/co/aikar/locales/MessageKey.java
+++ b/src/main/java/co/aikar/locales/MessageKey.java
@@ -1,6 +1,7 @@
 package co.aikar.locales;
 
 import java.util.Map;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -15,7 +16,7 @@ public class MessageKey implements MessageKeyProvider {
     }
 
     public static MessageKey of(String key) {
-        return keyMap.computeIfAbsent(key.toLowerCase().intern(), MessageKey::new);
+        return keyMap.computeIfAbsent(key.toLowerCase(Locale.ENGLISH).intern(), MessageKey::new);
     }
 
     public int hashCode() {


### PR DESCRIPTION
It causes bugs on the aikar/commands library. `I.toLowerCase()` -> `ı` and this char is in the Turkish language but not in English.
After merge and deploy, I will change the commands's dependency too
https://github.com/aikar/commands/blob/master/core/pom.xml#L52